### PR TITLE
Improve RFC template

### DIFF
--- a/template.md
+++ b/template.md
@@ -20,7 +20,26 @@ Explain the proposal as if it was already included in the engine and you were te
 
 ## \[Optional\] Examples
 
-This is the technical portion of the RFC. Explain the design in sufficient detail that:
+Lay out the examples that Bevy should add to either the examples folders or the doc comments to help new users discover and learn about this feature.
+These can either be completely new, or simply changes to existing examples.
+When completing this section, you can but do not have to write all of these examples yourself.
+Describing them in sufficient detail that another developer can do so is perfectly fine.
+If your examples are particularly long, please provide a brief description and link to a [Gist](https://gist.github.com/) for each.
+
+Most examples in Bevy aim to clearly demonstrate a single feature, group of closely related small features,
+or show how to accomplish a particular task (such as asset loading, creating a custom shader or how to test your app).
+In rare cases, creating new "game" examples is justified to demonstrate new features that open a complex class of functionality in a way that's hard to showcase in isolation or requires additional integration testing.
+
+Examples in Bevy should be:
+
+1. Working. They must compile and run, and should fail in obvious ways.
+2. Clear. They must use descriptive variable names, have reasonable code-quality, be formatted, and be appropriately commented.
+3. Relevant. They should use game-relevant fluff and explain why what they're demonstrating is useful.
+4. Minimal. They should be no larger or more complex than is needed to meet their other goals.
+This reduces maintenance burden and improves clarity when used as a reference.
+
+More complex demonstrations of functionality are also welcome, but for now belong in community tutorials or template games.
+
 ## Implementation strategy
 
 This is the technical portion of the RFC.

--- a/template.md
+++ b/template.md
@@ -28,7 +28,7 @@ and then focus in on the tricky details so that:
 - It is reasonably clear how the feature would be implemented.
 - Corner cases are dissected by example.
 
-When necessary, this section should return to the examples given in the previous section, and explain more the details that make those examples work.
+When necessary, this section should return to the examples given in the previous section and explain the implementation details that make them work.
 
 When writing this section be mindful of the following [repo guidelines](https://github.com/bevyengine/rfcs):
 

--- a/template.md
+++ b/template.md
@@ -24,7 +24,7 @@ Lay out the examples that Bevy should add to either the examples folders or the 
 These can either be completely new, or simply changes to existing examples.
 When completing this section, you can but do not have to write all of these examples yourself.
 Describing them in sufficient detail that another developer can do so is perfectly fine.
-If your examples are particularly long, please provide a brief description and link to a [Gist](https://gist.github.com/) for each.
+If your examples are particularly long, please use a [collapsible section](https://gist.github.com/pierrejoubert73/902cc94d79424356a8d20be2b382e1ab) with a summary for each example.
 
 Most examples in Bevy aim to clearly demonstrate a single feature, group of closely related small features,
 or show how to accomplish a particular task (such as asset loading, creating a custom shader or how to test your app).

--- a/template.md
+++ b/template.md
@@ -18,28 +18,6 @@ Explain the proposal as if it was already included in the engine and you were te
 - If applicable, provide sample error messages, deprecation warnings, or migration guidance.
 - If applicable, explain how this feature compares to similar existing features, and in what situations the user would use each one.
 
-## \[Optional\] Examples
-
-Lay out the examples that Bevy should add to either the examples folders or the doc comments to help new users discover and learn about this feature.
-These can either be completely new, or simply changes to existing examples.
-When completing this section, you can but do not have to write all of these examples yourself.
-Describing them in sufficient detail that another developer can do so is perfectly fine.
-If your examples are particularly long, please use a [collapsible section](https://gist.github.com/pierrejoubert73/902cc94d79424356a8d20be2b382e1ab) with a summary for each example.
-
-Most examples in Bevy aim to clearly demonstrate a single feature, group of closely related small features,
-or show how to accomplish a particular task (such as asset loading, creating a custom shader or how to test your app).
-In rare cases, creating new "game" examples is justified to demonstrate new features that open a complex class of functionality in a way that's hard to showcase in isolation or requires additional integration testing.
-
-Examples in Bevy should be:
-
-1. Working. They must compile and run, and should fail in obvious ways.
-2. Clear. They must use descriptive variable names, have reasonable code-quality, be formatted, and be appropriately commented.
-3. Relevant. They should use game-relevant fluff and explain why what they're demonstrating is useful.
-4. Minimal. They should be no larger or more complex than is needed to meet their other goals.
-This reduces maintenance burden and improves clarity when used as a reference.
-
-More complex demonstrations of functionality are also welcome, but for now belong in community tutorials or template games.
-
 ## Implementation strategy
 
 This is the technical portion of the RFC.

--- a/template.md
+++ b/template.md
@@ -18,15 +18,26 @@ Explain the proposal as if it was already included in the engine and you were te
 - If applicable, provide sample error messages, deprecation warnings, or migration guidance.
 - If applicable, explain how this feature compares to similar existing features, and in what situations the user would use each one.
 
-## Reference-level explanation
+## \[Optional\] Examples
 
 This is the technical portion of the RFC. Explain the design in sufficient detail that:
+## Implementation strategy
+
+This is the technical portion of the RFC.
+Try to capture the broad implementation strategy,
+and then focus in on the tricky details so that:
 
 - Its interaction with other features is clear.
 - It is reasonably clear how the feature would be implemented.
 - Corner cases are dissected by example.
 
-The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+When necessary, this section should return to the examples given in the previous section, and explain more the details that make those examples work.
+
+When writing this section be mindful of the following [repo guidelines](https://github.com/bevyengine/rfcs):
+
+- **RFCs should be scoped:** Try to avoid creating RFCs for huge design spaces that span many features. Try to pick a specific feature slice and describe it in as much detail as possible. Feel free to create multiple RFCs if you need multiple features.
+- **RFCs should avoid ambiguity:** Two developers implementing the same RFC should come up with nearly identical implementations.
+- **RFCs should be "implementable":** Merged RFCs should only depend on features from other merged RFCs and existing Bevy features. It is ok to create multiple dependent RFCs, but they should either be merged at the same time or have a clear merge order that ensures the "implementable" rule is respected.
 
 ## Drawbacks
 

--- a/template.md
+++ b/template.md
@@ -8,7 +8,7 @@ One paragraph explanation of the feature.
 
 Why are we doing this? What use cases does it support?
 
-## Guide-level explanation
+## User-facing explanation
 
 Explain the proposal as if it was already included in the engine and you were teaching it to another Bevy user. That generally means:
 

--- a/template.md
+++ b/template.md
@@ -66,6 +66,7 @@ Why should we *not* do this?
 
 - Why is this design the best in the space of possible designs?
 - What other designs have been considered and what is the rationale for not choosing them?
+- What objections immediately spring to mind? How have you addressed them?
 - What is the impact of not doing this?
 - Why is this important to implement as a feature of Bevy itself, rather than an ecosystem crate?
 


### PR DESCRIPTION
[RENDERED](https://github.com/colepoirier/rfcs/blob/rfc-section-update/template.md)

 I've worked with the RFC process a fair bit now, and while I generally like it, there are a few obvious warts that I'd like to get out of the way sooner than later.
 
 The basic problems I'm trying to solve are:

1. Guide-level and Reference-level are nonsensical and unclear as section names in the context of Bevy. These have been changed to User-facing Explanation and Implementation Strategy
2. Implementation Strategy's guidance was vague and fuzzy, and conflicted with Cart's directives for very detailed designs, as given in the README
3. Work done in RFCs is not easily translated to maintainable bits of Bevy. I've added a dedicated Examples section to discuss what should be in the examples folder, and pushed to make the User-Facing Explanation more portable to the Bevy book. 

This means that there's a rough mapping of sections onto durable work:
1. User-facing explanation: chopped up and moved to the Bevy book or other documentation.
2. Examples: used to improve the doc examples and the examples folder.
3. Implementation strategy: useful for making and reviewing the implementation PR.
4. Future work: moved to tracking issues on the main Bevy repo so valuable ideas aren't lost forever.

Everything else is ephemeral; preserved only to record why we made the decisions we did.