### PR TITLE
Stageless: a complete scheduling overhaul

### DIFF
--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -396,6 +396,8 @@ This design can be broken down into the following steps:
   - Include condition accesses when executor checks if systems can run.
   - Add inlined condition evaluation step in the executor.
 - Implement storing and retrieving systems (and schedules) from a resource.
+  - `Schedules` is effectively `Hashmap<ScheduleLabel, Schedule>`
+  - Each `Schedule` owns the graph data, and cross-schedule dependencies are impossible
   - Implement a descriptor coercion trait for `L: SystemLabel` types.
   - Implement the `Systems` type as described. (See **Appendix** or [this comment](https://github.com/bevyengine/bevy/pull/4090#issuecomment-1206585499) or [prototype PR impl](https://github.com/maniwani/bevy/blob/f5f80cd195b15d3912b4d90aade8750d8d1adc2e/crates/bevy_ecs/src/schedule_v3/mod.rs).)
 - Remove internal uses of "looping run criteria".

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -518,34 +518,13 @@ We think that's good enough for now.
 It's debatable whether that would increase or reduce cognitive burden.
 That can be revisited later too.)
 
-### Why did you change states from a stack to a basic FSM? Where is `OnUpdate(X)`?
+### Why did you change states from a stack to a basic FSM?
 
 If this RFC is merged and this design is implemented, we expect most of the problems that encouraged it to vanish.
 So rather than port pieces of the existing API, we think it's better to start fresh with a basic state machine and see what patterns emerge and what their limits are.
 If, after migration, a significant number of users are still turning towards a plugin to recover the lost stack functionality, we can consider upstreaming it again.
 
 A stack-based state machine should be trivial to implement though (i.e. with a loop inside the exclusive system).
-
-As for `OnUpdate(X)`... its interaction with `OnEnter(X)` was non-intuitive.
-Users often just wanted systems to run in their designated spots, but only when a certain state was active. That is much simpler to do now (see example below), so having a system set for this that you can only put in one spot seemed pointless.
-
-```rust
-fn main() {
-    App::new()
-        /* ... */
-        .add_system(
-            my_system
-            // A state being active has no inherent position in the schedule.
-            // Any system anywhere can be told to only run if a certain state is active.
-            .in_set(CoreSet::PostUpdate)
-            // This helper generates a condition that returns `true` if the state is currently `GameState::Playing`.
-            .run_if(state_equals(GameState::Playing))
-        )
-        /* ... */
-        .run();
-    )
-}
-```
 
 ### Why were the rules for system configuration chosen?
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -128,7 +128,7 @@ fn main() {
             // Macros can also accept system sets.
             MySystemSets::SubMenu,
             // Choose when to process commands with instances of this dedicated system.
-            apply_system_buffers.label(MySystems::FlushMenu),
+            apply_system_buffers.named(MySystems::FlushMenu),
           ]
           // Configure these together.
           .in_set(MySystemSets::Menu)
@@ -277,11 +277,9 @@ impl Plugin for ProjectilePlugin {
                 check_if_projectiles_hit,
                 despawn_projectiles_that_hit,
                 // Wherever you want commands to be applied, insert an instance of `apply_system_buffers`
-                // Systems with more than one copy in the schedule cannot be referred to
-                // via their type-derived automatic label, as this will result in confusing ambiguity
-                // or unintentional dependencies upon *all* copies of the system.
-                // Instead, label these systems
-                apply_system_buffers.label(MySystems::FlushProjectiles)
+                // Note: You cannot use type-derived labels for ordering if duplicates exist,
+                // so give this system a name if you want to order relative to it elsewhere.
+                apply_system_buffers.named(MySystems::FlushProjectiles)
                 fork_projectiles,
             ]
             .after(CoreSystems::FlushPostUpdate)

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -4,7 +4,7 @@
 
 The existing stage boundaries result in a large number of complications as they prevent us from operating across stages.
 Moreover, several related features (run criteria, states and fixed timesteps) are rather fragile and overly complex.
-This tangled mess needs to be holistically refactored: simplifying the scheduling model down into a single `Schedule`, moving towards an intent-based configuration style, taking full advantage of system labels as sets and leveraging exclusive systems to handle complex logic.
+This tangled mess needs to be holistically refactored: transferring the ownership of systems to an undivided `Schedule`, simplifying run criteria, taking full advantage of system labels as sets and leveraging exclusive systems to handle complex logic.
 
 ## Motivation
 
@@ -34,7 +34,7 @@ The following elements are substantially reworked:
 - fixed time steps (no longer a run criterion)
 - exclusive systems (no longer special-cased)
 - command processing (now performed in a `flush_commands` exclusive system)
-- labels (merged with the concept of system sets, can now be directly configured)
+- system labels and system sets (merged, can now be directly configured)
 - stages (yoten)
 
 ### Scheduling overview
@@ -230,7 +230,6 @@ Each state is associated with three groups of systems:
    1. `app.add_system(generate_map.in_set(OnEnter(GameState::Playing))`
 3. **On-exit systems:** these systems run once when the specified state is exited.
    1. `app.add_system(autosave.in_set(OnExit(GameState::Playing)))`
-
 
 While-active systems are by far the simplest: they're simply powered by run criteria.
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -414,7 +414,7 @@ By default, if something is ordered relative to an "unknown" system or set, that
 struct SystemRegistry {
     // Systems can only be run on the `World` that initialized them.
     world_id: Option<WorldId>,
-    // Maps a labels to identifiers.
+    // Maps labels to identifiers.
     // We need to be able to quickly look up specific systems and sets or iterate over them.
     // `RegId` is unique identifier, generated on insertion.
     ids: HashMap<BoxedSystemLabel, RegId>,

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -35,7 +35,7 @@ The following elements are substantially reworked:
 - exclusive systems (no longer special-cased)
 - command processing (now performed in a `flush_commands` exclusive system)
 - system labels and system sets (merged, can now be directly configured)
-- stages (yoten)
+- stages (removed)
 
 ### Scheduling overview
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -296,10 +296,6 @@ fn fancy_exclusive_system(world: &mut World) {
         // This runs the entire schedule on the world
         // Alternatively: world.run_schedule(ScheduleLabel)
         schedule.run(world);
-        
-        // This runs all systems with the provided label, obeying any internal ordering
-        // Alternatively: world.run_system_from_schedule(SystemLabel, ScheduleLabel)
-        schedule.run_systems(SystemLabel, world);
     });
 }
 ```

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -579,7 +579,8 @@ This was the strategy we used for `SystemSet`.
 
 - looks pretty
 - no limit to number of elements
-- doesn't work (different functions are different types, arrays must be homogoneous)
+- doesn't work (different functions are different types, arrays must be homogeneous)
+
 
 #### Tuples
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -274,6 +274,8 @@ impl Plugin for ProjectilePlugin {
                 check_if_projectiles_hit,
                 despawn_projectiles_that_hit,
                 // wherever you want commands to be applied, insert an instance of `apply_system_buffers`
+                // and when you add the same function multiple times, you have to use .named() to give
+                // each instance a unique name
                 apply_system_buffers.named(MySystems::FlushProjectiles)
                 fork_projectiles,
             ]

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -501,15 +501,21 @@ Whatever the changes, migration will be a big challenge.
 The proposed changes would affect the `App` and `Plugin` methods that all engine plugins and examples use, which will be a lot to review.
 At the same time, a large number of users are eagerly awaiting changes of this nature making it into the engine.
 
-If this RFC is merged, to expedite upstreaming while easing the burden on Bevy maintainers, we propose the following migration path:
+If this RFC is merged, to expedite upstreaming while easing the burden on Bevy maintainers, we propose the following migration path with 3 phases:
 
-- Add all the new stuff in a new module (i.e. `bevy_ecs::stageless`) that will live alongside an unchanged `bevy_ecs::schedule`, unused (and not in the prelude).
-- Implement a trait (i.e. `StagelessAppExt`) for `App` that can hook into the new module. Ultimately temporary.
-- Upstream these to `main`.
-- Publish a migration guide for the new API.
-- Slowly port over our engine plugins to the new methods provided through `StagelessAppExt`.
-- Deprecate the old module.
-- Replace the old module with the new module (and give the extension trait methods back their normal names).
+1. Add all the new stuff in a new module (i.e. `bevy_ecs::stageless`) that will live alongside an unchanged `bevy_ecs::schedule`, unused (and not in the prelude).
+   1. Implement a trait (i.e. `StagelessAppExt`) for `App` that can hook into the new module. Ultimately temporary.
+   2. Publish a migration guide for the new API.
+2. Port over our engine plugins to the new methods provided through `StagelessAppExt`.
+   1. Deprecate the old module to make sure everything has been migrated.
+3. Replace the old module with the new module.
+   1. Remove the extension trait.
+   2. Give the extension trait methods back their normal names.
+   3. Verify migration guide.
+
+Phase 1 will involve the bulk of the technical effort, and needs the closest reviews.
+Phase 2 and 3 will be tedious and trivial and involve very large numbers of lines changed.
+We will use a global code freeze during those steps to avoid merge conflicts, and merge Phase 2 and 3 ASAP.
 
 ### What's a good convention for naming system label types?
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -51,8 +51,8 @@ Ideally, we update everything in one go, as trying to spread the breaking change
 Let's define some terms.
 
 - **system**: stateful instance of a function that can access data stored in a world
-- **system set**: logical group of systems (can include other system sets)
-- **condition**: a function used to guard the execution of a system (set)
+- **system set**: logical group (subgraph) of systems (can include other system sets)
+- **condition**: function that must evaluate to `true` for a system (or systems in a set) to run
 - **dependency**: system (set) that must complete before another system (set) can run
 - **schedule** (noun): the executable form of a system set
 - **schedule** (verb): specify when and under what conditions systems run
@@ -69,10 +69,10 @@ Furthermore, systems and system sets can be ordered together and even grouped to
 
 In short, for any system or system set, you can:
 
-- define execution order relative to other systems or sets (e.g. "this system runs before A")
-- define conditions that must be true for it to run (e.g. "this system only runs if a player has full health")
-- define which set(s) it belongs to (which define common properties for everything underneath)
-  - if left unspecified, the system or set will be added under a (configureable) default set
+- define its execution order relative to other systems or sets (e.g. "this system runs before A")
+- define any conditions that must be true for it to run (e.g. "this system only runs if a player has full health")
+- define which set(s) it belongs to (which define properties that affect all systems underneath)
+  - if left unspecified, the system or set will be added under a default one (configureable)
 
 These properties are all additive.
 Adding another does not replace an existing one, and they cannot be removed.

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -570,14 +570,14 @@ fn main() {
 
 What happened here?
 
-Well, if interpreted as a system set, a type-derived label represents "the set of all anonymous systems of this type".
-Therefore, `before(apply_system_buffers)` meant "before all anonymous instances of `apply_system_buffers`" even though the user was most likely only thinking about the one they added themselves.
+Well, the problem is a type-derived label will name *all* anonymous systems of that type.
+Therefore, `before(apply_system_buffers)` means "before all anonymous instances of `apply_system_buffers`" even though the user was most likely only thinking about the one they added themselves.
 Totally obvious, right? (/s)
 
 Their program panicked because it saw a contradiction: `generate_commands` had to run before all `apply_system_buffers` instances and run after the one inside `X` at the same time.
 The only (reliable) solution here is for the user to give their instance of `apply_system_buffers` a unique name and use that name for ordering.
 
-So while it's natural to think of systems as "sets of one", treating their type-derived labels as system set names is subtly different and doing so would virtually guarantee errors when multiple copies exist, so we won't allow it.
+So while it's natural to think of systems as "sets of one", treating their type-derived labels as system set names is subtly different and doing so would virtually guarantee errors when multiple copies exist, so we just won't allow it.
 
 Now, we came up with three options to actually enforce that as an invariant:
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -106,9 +106,9 @@ impl Plugin for PhysicsPlugin{
 
         app
         // We can reuse this shared configuration on each of our sets
-        .add_set(Physics::Forces.configure(common_physics_config).before(Physics::CollisionDetection))
-        .add_set(Physics::CollisionDetection.configure(common_physics_config).before(Physics::CollisionHandling))
-        .add_set(Physics::CollisionHandling.configure(common_physics_config))
+        .configure_set(Physics::Forces.configure(common_physics_config).before(Physics::CollisionDetection))
+        .configure_set(Physics::CollisionDetection.configure(common_physics_config).before(Physics::CollisionHandling))
+        .configure_set(Physics::CollisionHandling.configure(common_physics_config))
         // And then apply that config to each of the systems that are part of this set
         .add_system(gravity.in_set(Physics::Forces))
         // These systems have a linear chain of ordering dependencies between them
@@ -192,7 +192,7 @@ fn main(){
     // The `resource_exists` and `resource_equals` functions generate a closure that you can stick in a run criteria
     .add_system(gravity.run_if(resource_exists(Gravity)))
     // Run criteria can be attached to system sets, allowing them to control all systems in that set
-    .add_set(GameSet::Physics.run_if(resource_equals(Paused(false))))
+    .configure_set(GameSet::Physics.run_if(resource_equals(Paused(false))))
     .run();
 }
 ```

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -245,7 +245,6 @@ As much as everyone loves to see systems running in parallel, sometimes a little
 Previous versions of Bevy treated these "exclusive" systems as a separate concept, with their own set of types and traits.
 They couldn't have `Local` params and could only be inserted at specific points of a stage.
 
-
 That is no longer the case.
 Exclusive systems are now just regular systems.
 They can have `Local` params and be scheduled wherever you want.

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -468,7 +468,7 @@ When the executor is presented with a ready system, we do the following:
 - Check that all the data accessed by the system, its run conditions (RC), and the RC of any sets it is under (that haven't been evaluated yet) is available.
   - If not, leave the system in the ready queue and move onto the next one.
 - If yes, evaluate the RC of the non-evaluated sets that the system is under in hierarchical order (from the outermost set to the innermost set).
-  - If any set's RC return false, mark all the systems (incl. current one) and sets under that set as completed/evaluated.
+  - If any set's RC return false, mark all the systems (incl. current one) and sets under that set as completed and evaluated.
   - If all of the set's RC return true, mark the set as evaluated.
 
 - If all the sets' RC returned true, now evaluate the system's RC.

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -337,7 +337,7 @@ As a result, you can transition states inside the fixed timestep without issue.
 
 A **fixed timestep** advances a fixed number of times each second.
 
-It's implemented as an exclusive system that runs a schedule zero or more times in a row (depending on how long the previous schedule execution took to complete).
+It's implemented as an exclusive system that runs a schedule zero or more times in a row (depending on how long the previous app update took to complete).
 
 When you supply a constant delta time value (the literal fixed timestep) inside the encapsulated systems, the result is consistent and repeatable behavior regardless of framerate (or even the presence of a GPU).
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -394,7 +394,7 @@ trait IntoConfiguredSet {
 
 There are several reasons an app may error due to improper scheduling.
 Most are related to graph solvability. The graph is solved in two different ways.
-The first is the graph where system sets and systems are considered graph nodes. This graph is called the hierarchical graph.
+The first is the graph where the nodes represent system sets and systems. This graph is called the hierarchical graph.
 The edges are checked for errors between systems and system sets at the same nesting level.
 The other graph that is checked is the flattened system graph. In this graph system sets are flattened into connections between only systems.
 So the dependencies on system sets become flattened into dependencies on the systems in the set.

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -393,23 +393,24 @@ Schedules store systems in a configured, initialized form.
 
 ```rust
 struct Schedule{
-   // Each schedule is associated with exactly one `World`, as systems must be initiliazed on it
+   // Each schedule is associated with exactly one `World`, as systems must be initiliazed on it.
+
    world_id: WorldId
-   // We need to be able to quickly look up specific systems and iterate over them
-   // `SystemId` should be a unique opaque identifier, generated on system insertion
+   // We need to be able to quickly look up specific systems and iterate over them.
+   // `SystemId` should be a unique opaque identifier, generated on system insertion.
    // We cannot use a Vec + a `usize` index as the identifier,
-   // as the identifier would not be stable when systems were removed, risking serious bugs
+   // as it would not be stable when systems were removed, risking serious bugs.
    systems: HashMap<SystemId, ConfiguredSystem>,
    // Stores the fully initialized, efficient graph of ordering constraints
    // for all systems in the schedule.
    // The properties of each set are passed down to specific systems to cache computation results.
    // `Graph` is a bikeshed-avoidance graph storage structure,
-   // the exact strategy should be benchmarked
+   // the exact strategy should be benchmarked.
    ordering_constraints: Graph<SystemId>,
    // Set configuration must be stored at the schedule level,
-   // rather than attached to specific set instances
+   // rather than attached to specific set instances.
    sets: HashMap<Box<dyn SystemLabel>, SystemSetConfig>,
-   // Used to check if mutation is allowed
+   // Used to check if mutation is allowed.
    currently_running: bool,
 }
 ```
@@ -452,7 +453,7 @@ struct SystemConfig {
    run_criteria: Vec<SystemId>,
    // The combined access requirements of the system and its run criteria
    joint_access: FilteredAccessSet<ComponentId>,
-   sets: Vec<Box dyn SystemLabel>,
+   sets: Vec<Box<dyn SystemLabel>>,
 }
 
 struct SystemSetConfig {

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -331,7 +331,7 @@ Unlike in previous versions of Bevy, states and the fixed timestep are no longer
 
 Instead, systems that are part of states or fixed time steps are simply added under a separate system set that will be retrieved and ran by an exclusive system.
 
-As a result, you can transition states or add additional run criteria inside the fixed timestep without issue.
+As a result, you can transition states inside the fixed timestep without issue.
 
 ### Fixed timestep
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -511,7 +511,8 @@ We need to:
 For this RFC, let's begin with the very simplest strategy: for each pair of systems with a flushed ordering constraint, ensure that a flushing system of the appropriate type is strictly after the first system, and strictly before the second.
 
 We can check if the flushing system is of the appropriate type by checking the type id of the function pointer stored in the `System`.
-This is cached in the `system_function_type_map` field of the `Schedule` for efficient lookup, yielding the relevant `SystemIds`.
+This is cached in the `system_function_type_map` field of the `Schedule` for efficient lookup, yielding the relevant `SystemId`s.
+
 
 With the ids of the relevant systems in hand, we can check each constraint: for each pair of systems, we must check that at least one of the relevant flushing systems is between them.
 To do so, we need to check both direct *and* transitive strict ordering dependencies, using a depth-first search to walk backwards from the later system using the `CachedOrdering` until a flushing system is reached, and then walking back further from that flushing system until the originating system is reached.

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -710,25 +710,36 @@ This strategy is used for the `vec![1,2,3]` macro in the standard library.
 
 ## Future possibilities
 
-There are a few proposals that were directly split from this RFC:
+After this RFC is implemented, there's valuable work to be done to improve ergonomics:
 
-1. Unnecessary dependency removal ([RFC #47](https://github.com/bevyengine/rfcs/pull/47)).
-2. Configurable system set atomicity ([RFC #46](https://github.com/bevyengine/rfcs/pull/46)).
-3. Automatic (opt-in) insertion of command application and state transition systems (see discussion in [RFC #34](https://github.com/bevyengine/rfcs/pull/34)).
-4. "Command-flushed" ordering constraints (dependencies that will ensure the pair is separated by command application).
+1. Automatic (opt-in) insertion of command application and state transition systems (see discussion in [RFC #34](https://github.com/bevyengine/rfcs/pull/34)).
+2. Add [manual dependency graph construction](https://github.com/bevyengine/bevy/pull/2381) methods.
 
-There are also lots of related but non-urgent areas for follow-up research:
+Clean up related code:
+
+1. Revisit [plugin definition and plugin configuration](https://github.com/bevyengine/bevy/issues/2160).
+2. Move command queues into the `World` so that exclusive systems can drain them directly (e.g. in some user-defined order).
+3. Cloning registered systems. (This probably warrants its own RFC, but it fits with the multiple worlds discussion.)
+
+Build out solid tooling:
 
 1. Improve tools for reporting and resolving system execution order ambiguities.
-2. Revisit plugin definition and plugin configuration.
-3. Cloning registered systems. (This probably warrants its own RFC, but it fits with the multiple worlds discussion.)
-4. Add [manual dependency graph construction](https://github.com/bevyengine/bevy/pull/2381) methods.
-5. Seeded, fully deterministic system execution orders: useful for debugging system order bugs and optimization work.
-6. Move command queues into the `World` so that exclusive systems can drain them directly (e.g. in some user-defined order).
-7. Compose conditions via arbitrary boolean expressions.
-8. Support automatic insertion and removal of systems to reduce schedule clutter and support other forms of one-off logic.
-9. Run schedules without `&mut World`, inferring access based on the systems inside.
-10. [One-shot systems](https://github.com/bevyengine/bevy/pulls?q=is%3Apr+is%3Aopen+one-shot+system), where systems are evaluated one-at-a-time on an ad hoc basis.
+2. System graph visualization.
+3. Seeded, fully deterministic system execution orders: useful for debugging system order bugs and optimization work.
+
+Improve performance:
+
+1. Run schedules without `&mut World`, inferring access based on the systems inside.
+2. Assorted benchmarking and optimization of various scheduling strategies.
+
+Or increase scheduling expressivity:
+
+1. Compose conditions via arbitrary boolean expressions.
+2. Unnecessary dependency removal ([RFC #47](https://github.com/bevyengine/rfcs/pull/47)).
+3. "Command-flushed" ordering constraints (dependencies that will ensure the pair is separated by command application).
+4. Configurable system set atomicity ([RFC #46](https://github.com/bevyengine/rfcs/pull/46)), where the data that a group of systems accesses is locked until all are completed.
+5. Add [runtime insertion and removal of systems](https://github.com/bevyengine/bevy/issues/279).
+6. Support automatic insertion and removal of systems to reduce schedule clutter and support other [forms of one-off logic](https://github.com/bevyengine/bevy/pull/4090).
 
 ## Appendix
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -292,10 +292,9 @@ Each system is stored within a `Schedule`, which themselves live within a public
 ```rust
 fn fancy_exclusive_system(world: &mut World) {
     // removes the selected schedule from Schedules, executes a fn with it, then returns it to the world
-    world.schedule_scope(ScheduleLabel, |world, mut schedule| {
+    while fancy_logic() {
         // This runs the entire schedule on the world
-        // Alternatively: world.run_schedule(ScheduleLabel)
-        schedule.run(world);
+        world.run_schedule(ScheduleLabel);
     });
 }
 ```
@@ -592,7 +591,7 @@ Likewise, resolving the error is very simple: just name the systems.
 
 Internally, systems and sets are given unique identifiers and those are used for graph construction.
 This means you can do `add_system(apply_system_buffers.after(X))` multiple times or use the `chain!` macro with multiple unnamed instances of the same function without having to name any of them.
-A system only needs a name when you want to do `before(name)` or `after(name)` somewhere else. 
+A system only needs a name when you want to do `before(name)` or `after(name)` somewhere else.
 
 *Note: In case it wasn't already clear, system chaining introduces new instances of systems. It does not reuse existing ones.*
 
@@ -925,12 +924,8 @@ pub fn apply_state_transition<S: State>(world: &mut World) {
             let new = world.resource_mut::<NextState<S>>().take().unwrap();
             let old = current_state.replace(new);
             // and run the transitions
-            world.schedule_scope(OnExit(old), |world, mut schedule| {
-                schedule.run(world);
-            });
-            world.schedule_scope(OnEnter(new), |world, mut schedule| {
-                schedule.run(world);
-            });
+            world.run_schedule(OnExit(old));
+            world.run_schedule(OnEnter(new));
         }
     });
 }

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -345,7 +345,6 @@ The current state of type `S` can be read from the `CurrentState<S: State>` reso
 Bevy provides a simple but convenient abstraction to link the transitions of a state `S::Variant` with system sets, specifically an `OnEnter(S::Variant)` system set and an `OnExit(S::Variant)` system set.
 An exclusive system called `apply_state_transition<S: State>` can be scheduled, which will retrieve and run these schedules as appropriate when a transition is queued in the `NextState<S: State>` resource.
 
-
 ```rust
 fn main() {
     App::new()
@@ -581,7 +580,6 @@ This was the strategy we used for `SystemSet`.
 - no limit to number of elements
 - doesn't work (different functions are different types, arrays must be homogeneous)
 
-
 #### Tuples
 
 ```rust
@@ -801,6 +799,7 @@ So what are the errors?
 1. A dependency graph contains a loop or cycle.
 2. The hierarchical graph contains a loop or cycle.
 3. The hierarchical graph has a transitive edge. Example:
+
     ```rust
     app
         .add_set(A);
@@ -809,6 +808,7 @@ So what are the errors?
         // `A` cannot be a parent and grandparent to `C` at same time. 
         .add_set(C.in_set(B).in_set(A))
     ```
+
 4. You called `.in_set` with a label that belongs to a system, rather than a system set.
 5. (Optional) You have a dependency between two things that aren't siblings in a common set. That edge will not appear in either set's dependency graph, only in the flattened graph of an overarching set. This can lead to unwanted implicit ordering between systems in different sets.
 6. (Optional) You referenced an "unknown" label. e.g. `.after(label)` references a label that doesn't belong to any known system or system set.
@@ -866,7 +866,7 @@ Each condition is evaluated at most once.
 Since most of these functions are probably simple tests, we don't spawn tasks for them, which avoids locking other systems out of the data they access.
 Likewise, we don't spawn tasks for systems that get skipped. This lightweight approach minimizes task overhead.
 
-### States
+### Implementing states
 
 The implementation of a basic state machine can be very simple in this new scheme.
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -332,6 +332,24 @@ A **fixed timestep** advances a fixed number of times each second.
 It's implemented as an exclusive system that runs a schedule zero or more times in a row (depending on how long the previous app update took to complete).
 When you supply a constant delta time value (the literal fixed timestep) inside the encapsulated systems, the result is consistent and repeatable behavior regardless of framerate (or even the presence of a GPU).
 
+```rust
+fn main() {
+    App::new()
+        .add_systems(
+            // Conveneniently ordering these systems relative to each other
+            chain!([
+               apply_forces,
+               apply_acceleration,
+               apply_velocity
+            ])
+            // Ensuring they run on a fixed timestep
+            // as part of the `FixedTimestep` set
+            .in_set(FixedTimestep)
+         )
+        .run();
+}
+```
+
 ### States
 
 **State machines** allow for ad-hoc execution of complex logic in response to state transitions.

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -356,7 +356,6 @@ fn main() {
 
 ## Implementation strategy
 
-
 This design can be broken down into the following steps:
 
 - Normalize exclusive systems.
@@ -383,6 +382,8 @@ This design can be broken down into the following steps:
 - Misc.
   - Implement bulk scheduling capabilities (`.add_systems`, descriptor wrapper enum, and convenience macros like `chain!`)
     - Rebrand "system chaining" (e.g. `ChainSystem`) into something else, like "system piping".
+
+There is a prototype implementation of these changes (in a separate module) here: bevyengine/bevy#4391 (The **Appendix** shows several snippets from this.)
 
 ## Drawbacks
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -166,15 +166,11 @@ Run criteria are not systems, but can be created from systems which can read (bu
 You can specify run criteria in several different ways:
 
 ```rust
-// This is just an ordinary system: timers need to be ticked!
-fn tick_construction_timer(timer: ResMut<ConstructionTimer>, time: Res<Time>){
-    timer.tick(time.delta());
-}
-
-// This function can be used as a run criterion system,
+// This function can be used as a run criterion,
 // because it does not mutate data and returns `bool`
-fn construction_timer_finished(timer: Res<ConstructionTimer>) -> bool {
-    timer.finished()
+fn construction_timer_finished(mut timer: ResMut<ConstructionTimer>) -> bool {
+   timer.tick(time.delta());
+   timer.finished()
 }
 
 // You can use queries, event readers and resources with arbitrarily complex internal logic
@@ -186,12 +182,8 @@ fn main(){
     App::new()
     .add_plugins(DefaultPlugins)
     // We can add functions with read-only system parameters as run criteria
-    .add_systems((
-
-       tick_construction_timer, 
-       update_construction_progress)
-       .chain()
-       .run_if(construction_timer_finished)
+    .add_system(
+       update_construction_progress.run_if(construction_timer_finished)
     )
    .add_system(system_meltdown_mitigation.run_if(too_many_enemies))
     // We can use closures for simple one-off run criteria, 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -590,7 +590,9 @@ Now, we came up with three options to actually enforce that as an invariant:
 We like (3) because it doesn't put undue burden on the user or introduce unclear implicit behavior.
 Likewise, resolving the error is very simple: just name the systems.
 
-Internally, systems and sets are given unique identifiers and those are used for graph construction. This means you can do `add_system(apply_system_buffers.after(X))` multiple times or use the `chain!` macro with multiple unnamed instances of the same function without having to name any of them. A system only needs a name when you want to do `before(name)` or `after(name)` somewhere else. 
+Internally, systems and sets are given unique identifiers and those are used for graph construction.
+This means you can do `add_system(apply_system_buffers.after(X))` multiple times or use the `chain!` macro with multiple unnamed instances of the same function without having to name any of them.
+A system only needs a name when you want to do `before(name)` or `after(name)` somewhere else. 
 
 *Note: In case it wasn't already clear, system chaining introduces new instances of systems. It does not reuse existing ones.*
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -405,11 +405,21 @@ There is a prototype implementation of these changes (in a separate module) here
 
 ## Rationale and alternatives
 
-### Why did you call them "system sets" instead of "labels" (or some other term)?
+### How are system sets any different from labels?
 
-"Label" sounds really abstract, while "system set" more closely matches how it's interpreted during dependency graph solving.
-Formally, a system set is a subgraph embedded somewhere in the graph of its parent set(s) (unless it's a root).
-It's like a "super node" that encapsulates everything inside it.
+Formally speaking, a system set is a subgraph.
+It's a node in the graph of its parent set(s) (unless it's a root).
+
+We wanted to make it clear that labels are *names* for things and not *tags*.
+You can name systems and system sets.
+
+Today, if you add multiple labels to a system, the expectation is that each label is involved in at least one dependency, so you're actually positioning things, not categorizing them.
+We have made this explicit.
+You position things within sets (and because sets can be "nested", we've added depth).
+
+Although users don't normally add labels and leave them "unconstrained", such a thing does have a direct analogue in this design.
+You can simply include systems in additional sets that are decoupled from the ones you'd normally execute.
+In that case, you'd be using "set" as a simple abstract group instead of a scoped dependency graph.
 
 ### If users can configure system sets, can they control where systems from third-party plugins are added?
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -47,8 +47,8 @@ To build a Bevy app, users have to specify when their systems should run. By def
 
 In short, for any system or system set, users can:
 
-- add execution order constraints relative to other systems or sets (i.e. "this system runs before A")
-- add conditions that must be true for it to run (i.e. "this system only runs if a player has full health")
+- add execution order constraints relative to other systems or sets (e.g. "this system runs before A")
+- add conditions that must be true for it to run (e.g. "this system only runs if a player has full health")
 - add it to sets (which define common behavior for all systems within that set)
 
 These properties are all additive.

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -485,8 +485,18 @@ Not being able to schedule plugin systems is a source of [significant user pain]
 We thought plugins exporting system set labels and users deciding where to position them in their schedules makes for a better balance.
 A popular physics plugin [has already implemented something like this](https://github.com/dimforge/bevy_rapier/pull/169) (partly [inspired](https://discord.com/channels/691052431525675048/742569353878437978/970075559679893594) by this effort).
 
-As you can put sets in sets, plugin authors can choose whatever level of logical granularity they want to expose to you *and* still ensure that important logical invariants hold.
-Users will only be able schedule things at the level the plugin makes public.
+There are three key rules for system configuration:
+
+1. You can always add configuration (for any publically labeled set).
+2. You can never remove configuration.
+3. Contradictory configuration is invalid, even if it's locally consistent.
+
+The first rule ensures that plugins can export flexible, reusable functionality, which can be adapted to fit into the user's app.
+The second rule allows plugins to enforce critical internal invariants, even in the face of additional tweaking.
+The final rule is a resolution mechanism: rather than trying to guess which rule should take priority, Bevy will fail quickly, clearly and early to allow programmers to detect and fix the underlying problem.
+
+Plugin authors can choose whatever level of logical granularity they want to expose to you *and* still ensure that important logical invariants hold.
+Users will only be able schedule systems (and sets of systems) at the level the plugin makes public.
 And if their public API is relatively stable, plugins could even make large internal changes without breaking user apps.
 
 ### If exclusive systems can go anywhere, won't users have a harder time resolving ambiguity errors?
@@ -525,18 +535,6 @@ So rather than port pieces of the existing API, we think it's better to start fr
 If, after migration, a significant number of users are still turning towards a plugin to recover the lost stack functionality, we can consider upstreaming it again.
 
 A stack-based state machine should be trivial to implement though (i.e. with a loop inside the exclusive system).
-
-### Why were the rules for system configuration chosen?
-
-There are three key rules for system configuration:
-
-1. You can always add configuration (for any publically labeled set).
-2. You can never remove configuration.
-3. Contradictory configuration is invalid, even if it's locally consistent.
-
-The first rule ensures that plugins can export flexible, reusable functionality, which can be adapted to fit into the user's app.
-The second rule allows plugins to enforce critical internal invariants, even in the face of additional tweaking.
-The final rule is a resolution mechanism: rather than trying to guess which rule should take priority, Bevy will fail quickly, clearly and early to allow programmers to detect and fix the underlying problem.
 
 ## Unresolved questions
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -405,6 +405,28 @@ This design can be broken down into the following steps:
 
 There is a prototype implementation of these changes (in a separate module) here: bevyengine/bevy#4391 (The **Appendix** shows several snippets from this.)
 
+### Migration strategy
+
+Whatever the changes, migration will be a big challenge.
+The proposed changes would affect the `App` and `Plugin` methods that all engine plugins and examples use, which will be a lot to review.
+At the same time, a large number of users are eagerly awaiting changes of this nature making it into the engine.
+
+If this RFC is merged, to expedite upstreaming while easing the burden on Bevy maintainers, we propose the following migration path with 3 phases:
+
+1. Add all the new stuff in a new module (i.e. `bevy_ecs::stageless`) that will live alongside an unchanged `bevy_ecs::schedule`, unused (and not in the prelude).
+   1. Implement a trait (i.e. `StagelessAppExt`) for `App` that can hook into the new module. Ultimately temporary.
+   2. Publish a migration guide for the new API.
+2. Port over our engine plugins to the new methods provided through `StagelessAppExt`.
+   1. Deprecate the old module to make sure everything has been migrated.
+3. Replace the old module with the new module.
+   1. Remove the extension trait.
+   2. Give the extension trait methods back their normal names.
+   3. Verify migration guide.
+
+Phase 1 will involve the bulk of the technical effort, and needs the closest reviews.
+Phase 2 and 3 will be tedious and trivial and involve very large numbers of lines changed.
+We will use a global code freeze during those steps to avoid merge conflicts, and merge Phase 2 and 3 ASAP.
+
 ## Drawbacks
 
 1. Migration: These will be major breaking changes for every Bevy user.
@@ -512,28 +534,6 @@ fn main() {
 ```
 
 ## Unresolved questions
-
-### What is the best way to approach migration?
-
-Whatever the changes, migration will be a big challenge.
-The proposed changes would affect the `App` and `Plugin` methods that all engine plugins and examples use, which will be a lot to review.
-At the same time, a large number of users are eagerly awaiting changes of this nature making it into the engine.
-
-If this RFC is merged, to expedite upstreaming while easing the burden on Bevy maintainers, we propose the following migration path with 3 phases:
-
-1. Add all the new stuff in a new module (i.e. `bevy_ecs::stageless`) that will live alongside an unchanged `bevy_ecs::schedule`, unused (and not in the prelude).
-   1. Implement a trait (i.e. `StagelessAppExt`) for `App` that can hook into the new module. Ultimately temporary.
-   2. Publish a migration guide for the new API.
-2. Port over our engine plugins to the new methods provided through `StagelessAppExt`.
-   1. Deprecate the old module to make sure everything has been migrated.
-3. Replace the old module with the new module.
-   1. Remove the extension trait.
-   2. Give the extension trait methods back their normal names.
-   3. Verify migration guide.
-
-Phase 1 will involve the bulk of the technical effort, and needs the closest reviews.
-Phase 2 and 3 will be tedious and trivial and involve very large numbers of lines changed.
-We will use a global code freeze during those steps to avoid merge conflicts, and merge Phase 2 and 3 ASAP.
 
 ### What's a good convention for naming system label types?
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -318,7 +318,6 @@ fn example_run_schedule_system(world: &mut World) {
 This pattern is your go-to when your scheduling needs grow beyond "each system runs once per app update".
 You might want to:
 
-
 - repeatedly loop over a sequence of game logic several times in a single app update (e.g. fixed timestep, action queue)
 - have complex branches in your schedule (e.g. state transitions)
 - change to a different threading model for some portion of your systems
@@ -327,9 +326,7 @@ You might want to:
 As long as you have `&mut World`, from an exclusive system or command, you can extract anything available in the `Systems` resource and run it.
 
 Unlike in previous versions of Bevy, states and the fixed timestep are no longer powered by run criteria.
-
 Instead, systems that are part of states or fixed time steps are simply added under a separate system set that will be retrieved and ran by an exclusive system.
-
 As a result, you can transition states inside the fixed timestep without issue.
 
 ### Fixed timestep
@@ -337,7 +334,6 @@ As a result, you can transition states inside the fixed timestep without issue.
 A **fixed timestep** advances a fixed number of times each second.
 
 It's implemented as an exclusive system that runs a schedule zero or more times in a row (depending on how long the previous app update took to complete).
-
 When you supply a constant delta time value (the literal fixed timestep) inside the encapsulated systems, the result is consistent and repeatable behavior regardless of framerate (or even the presence of a GPU).
 
 ### States
@@ -350,7 +346,8 @@ It's common to see enums used for state types.
 You can have multiple independently controlled states, or defined nested states with enums.
 The current state of type `S` can be read from the `CurrentState<S: State>` resource.
 
-Bevy provides a simple but convenient abstraction to link the transitions of a state `S::Variant` with system sets, specifically an `OnEnter(S::Variant)` system set and an `OnExit(S::Variant)` system set. An exclusive system called `apply_state_transition<S: State>` can be scheduled, which will retrieve and run these schedules as appropriate when a transition is queued in the `NextState<S: State>` resource.
+Bevy provides a simple but convenient abstraction to link the transitions of a state `S::Variant` with system sets, specifically an `OnEnter(S::Variant)` system set and an `OnExit(S::Variant)` system set.
+An exclusive system called `apply_state_transition<S: State>` can be scheduled, which will retrieve and run these schedules as appropriate when a transition is queued in the `NextState<S: State>` resource.
 
 
 ```rust
@@ -381,7 +378,6 @@ This design can be broken down into the following steps:
   - Define the trait (i.e. `IntoRunCondition`) and blanket implement it for compatible functions.
   - Implement `.run_if` descriptor method.
   - Include condition accesses when doing ambiguity checks.
-
   - Include condition accesses when executor checks if systems can run.
   - Add inlined condition evaluation step in the executor.
 - Implement storing and retrieving systems (and schedules) from a resource.
@@ -645,7 +641,6 @@ There are also lots of related but non-urgent areas for follow-up research:
 4. Add [manual dependency graph construction](https://github.com/bevyengine/bevy/pull/2381) methods.
 5. Seeded, fully deterministic system execution orders: useful for debugging system order bugs and optimization work.
 6. Move command queues into the `World` so that exclusive systems can drain them directly (e.g. in some user-defined order).
-
 7. Compose conditions via arbitrary boolean expressions.
 8. Support automatic insertion and removal of systems to reduce schedule clutter and support other forms of one-off logic.
 9. Run schedules without `&mut World`, inferring access based on the systems inside.

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -189,7 +189,8 @@ impl Plugin for PhysicsPlugin {
 
 ### Deciding if systems run with conditions
 
-While dependencies determine *when* systems runs, **conditions** determine *if* they run at all.
+While dependencies determine *when* systems run, **conditions** determine *if* they run at all.
+
 Functions with compatible signatures (immutable `World` data access and `bool` output) can be attached to systems and system sets as conditions.
 A system or system set will only run if all of its conditions return `true`.
 If one of its conditions returns `false`, the system (or members of the system set) will be skipped.

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -291,7 +291,6 @@ Each system is stored within a `Schedule`, which themselves live within a public
 
 ```rust
 fn fancy_exclusive_system(world: &mut World) {
-    // removes the selected schedule from Schedules, executes a fn with it, then returns it to the world
     while fancy_logic() {
         // This runs the entire schedule on the world
         world.run_schedule(ScheduleLabel);

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -374,8 +374,11 @@ fn main() {
 }
 ```
 
-By default, all state transitions are evaluated just before `CoreSystems::Update`, in a `CoreSystems::ApplyStateTransitions` set.
-Calling `App::add_state` adds the corresponding `CurrentState` and `NextState` resources, and registers a `apply_state_transition<S>` system.
+Calling `App::add_state<S>`:
+
+1. Adds the corresponding `CurrentState<S>` and `NextState<S>` resources
+2. Adds a `OnUpdate(S::Variant)` set for each valid state. These sets are nested inside of `CoreSystems::Update` by default.
+3. Registers a `apply_state_transition<S>` system, which is evaluated just before `CoreSystems::Update`, in a `CoreSystems::ApplyStateTransitions` set..
 
 ## Implementation strategy
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -369,13 +369,22 @@ An exclusive system called `apply_state_transition<S: State>` can be scheduled, 
 ```rust
 fn main() {
     App::new()
+        .add_state::<GameState>()
         /* ... */
+        // These systems only run as part of the state transition logic
         .add_system(load_map.in_set(OnEnter(GameState::Playing)))
         .add_system(autosave.in_set(OnExit(GameState::Playing)))
+        // This system will be added under the `OnUpdate(GameState::Playing)` set
+        .add_system(run.in_set(OnUpdate(GameState::Playing)))
+        // This system will not be part of the set above, but will otherwise follow the same rules
+        .add_system(jump.run_if(state_equals(GameState::Playing)))
         /* ... */
         .run();
 }
 ```
+
+By default, all state transitions are evaluated just before `CoreSystems::Update`, in a `CoreSystems::ApplyStateTransitions` set.
+Calling `App::add_state` adds the corresponding `CurrentState` and `NextState` resources, and registers a `apply_state_transition<S>` system.
 
 ## Implementation strategy
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -87,14 +87,14 @@ enum GameState {
     Paused
 }
 
-#[derive(SetLabel)]
+#[derive(SystemLabel)]
 enum MySystemSets {
     Update,
     Menu,
     SubMenu,
 }
 
-#[derive(SetLabel)]
+#[derive(SystemLabel)]
 enum MySystems {
     FlushMenu,
 }
@@ -153,7 +153,7 @@ For example, using `systems![a, b, c, ...].chain()` (or the `chain![a, b, c, ...
 Bevy's `MinimalPlugins` and `DefaultPlugins` plugin groups include several built-in system sets.
 
 ```rust
-#[derive(SetLabel)]
+#[derive(SystemLabel)]
 enum Physics {
     ComputeForces,
     DetectCollisions,
@@ -256,7 +256,7 @@ If one system depends on the effects of commands from another, make sure an `app
 ```rust
 use bevy::prelude::*;
 
-#[derive(SetLabel)]
+#[derive(SystemLabel)]
 enum MySystems {
     /* ... */
     FlushProjectiles,
@@ -393,7 +393,7 @@ This design can be broken down into the following steps:
   - Include condition accesses when executor checks if systems can run.
   - Add inlined condition evaluation step in the executor.
 - Implement storing and retrieving systems (and schedules) from a resource.
-  - Implement a descriptor coercion trait for `L: SetLabel` types.
+  - Implement a descriptor coercion trait for `L: SystemLabel` types.
   - Implement the `Systems` type as described. (See **Appendix** or [this comment](https://github.com/bevyengine/bevy/pull/4090#issuecomment-1206585499) or [prototype PR impl](https://github.com/maniwani/bevy/blob/f5f80cd195b15d3912b4d90aade8750d8d1adc2e/crates/bevy_ecs/src/schedule_v3/mod.rs).)
 - Remove internal uses of "looping run criteria".
   - Convert fixed timestep and state transitions into exclusive systems that each retrieve and run a schedule.
@@ -709,7 +709,7 @@ enum NodeId {
 #[derive(Resource)]
 pub struct Systems {
     // `NodeId` is unique identifier, generated on insertion
-    index: HashMap<SetLabelId, NodeId>,
+    index: HashMap<SystemLabelId, NodeId>,
     next_id: u64,
 
     // long-term storage
@@ -766,19 +766,19 @@ As a bonus, schedule construction will become completely order-independent as ev
 pub trait IntoConfiguredSystem<Params> {
     fn configure(self) -> ConfiguredSystem;
     fn configure_with(self, config: Config) -> ConfiguredSystem;
-    fn before<M>(self, label: impl AsSetLabel<M>) -> ConfiguredSystem;
-    fn after<M>(self, label: impl AsSetLabel<M>) -> ConfiguredSystem;
-    fn in_set(self, set: impl SetLabel) -> ConfiguredSystem;
+    fn before<M>(self, label: impl AsSystemLabel<M>) -> ConfiguredSystem;
+    fn after<M>(self, label: impl AsSystemLabel<M>) -> ConfiguredSystem;
+    fn in_set(self, set: impl SystemLabel) -> ConfiguredSystem;
     fn run_if<P>(self, condition: impl IntoRunCondition<P>) -> ConfiguredSystem;
-    fn named(self, name: impl SetLabel) -> ConfiguredSystem;
+    fn named(self, name: impl SystemLabel) -> ConfiguredSystem;
 }
 
 pub trait IntoConfiguredSystemSet {
     fn configure(self) -> ConfiguredSystemSet;
     fn configure_with(self, config: Config) -> ConfiguredSystemSet;
-    fn before<M>(self, label: impl AsSetLabel<M>) -> ConfiguredSystemSet;
-    fn after<M>(self, label: impl AsSetLabel<M>) -> ConfiguredSystemSet;
-    fn in_set(self, set: impl SetLabel) -> ConfiguredSystemSet;
+    fn before<M>(self, label: impl AsSystemLabel<M>) -> ConfiguredSystemSet;
+    fn after<M>(self, label: impl AsSystemLabel<M>) -> ConfiguredSystemSet;
+    fn in_set(self, set: impl SystemLabel) -> ConfiguredSystemSet;
     fn run_if<P>(self, condition: impl IntoRunCondition<P>) -> ConfiguredSystemSet;
 }
 
@@ -788,19 +788,19 @@ enum Order {
 }
 
 struct Config {
-    sets: HashSet<SetLabelId>,
-    dependencies: Vec<(Order, SetLabelId)>,
+    sets: HashSet<SystemLabelId>,
+    dependencies: Vec<(Order, SystemLabelId)>,
     conditions: Vec<BoxedRunCondition>,
 }
 
 struct ConfiguredSystem {
     system: BoxedSystem,
     config: Config,
-    instance_name: SetLabelId,
+    instance_name: SystemLabelId,
 }
 
 struct ConfiguredSystemSet {
-    set: SetLabelId,
+    set: SystemLabelId,
     config: Config,
 }
 ```
@@ -905,10 +905,10 @@ pub struct NextState<S: State>(pub Option<S>);
 
 impl<S: State> NextState<S> { /* ... */ }
 
-#[derive(SetLabel)]
+#[derive(SystemLabel)]
 pub struct OnEnter<S: State>(S);
 
-#[derive(SetLabel)]
+#[derive(SystemLabel)]
 pub struct OnExit<S: State>(S);
 
 // add (multiple instances of) this system to your schedule

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -153,13 +153,6 @@ For example, using `systems![a, b, c, ...].chain()` (or the `chain![a, b, c, ...
 
 Bevy's `MinimalPlugins` and `DefaultPlugins` plugin groups include several built-in system sets.
 
-```rust
-fn main() {
-    App::new()
-        .add_systems(chain![compute_damage, deal_damage, check_for_death].in_set(GameSet::Combat))
-        .run()
-}
-```
 
 ```rust
 #[derive(SystemLabel)]

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -255,7 +255,7 @@ That is no longer the case.
 Exclusive systems are now just regular systems.
 They can have `Local` params and be scheduled wherever you want.
 
-Command application is now conducted through an exclusive system called `apply_system_buffers`.
+Command application is now signaled through an exclusive system called `apply_system_buffers`.
 You can add instances of this system anywhere in your schedule.
 If one system depends on the effects of commands from another, make sure an `apply_system_buffers` appears somewhere between them.
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -431,6 +431,36 @@ As you can put sets in sets, plugin authors can choose whatever level of logical
 Users will only be able schedule things at the level the plugin makes public.
 And if their public API is relatively stable, plugins could even make large internal changes without breaking user apps.
 
+### If exclusive systems can go anywhere, won't users have a harder time resolving ambiguity errors?
+
+You *will* have to be more careful once exclusive systems can go anywhere.
+
+That said, Bevy won't fail to detect pairs of conflicting + ambiguously-ordered things.
+The checker can point out what's ambiguous before *and* after flattening dependency graphs.
+(i.e. Bevy can report that system A conflicts with system set X before reporting the specific pairs of conflicting systems).
+
+We hope system sets will help reduce the cognitive burden here and naturally lead users to patterns with fewer errors.
+Likewise, if users also become responsible for scheduling sets exported by plugins, it will be within their power to resolve any errors.
+
+Still, we have identified follow-up work to improve this.
+
+If you have two ambiguously-ordered system sets that conflict, you probably won't get the behavior you expect if all their systems just get mixed together.
+[RFC #46](https://github.com/bevyengine/rfcs/pull/46) (which spun out of this one) aims to give system sets configurable atomicity to prevent this mixing from happening, although the ambiguity would still exist.
+
+### Why is command application scheduled with an exclusive system?
+
+What users would like best is an open question.
+
+Several earlier RFCs talked about expressing more exact dependencies, e.g. `B.after_buffers_of(A)`, where such graph edges could hypothetically be used to automatically determine when to apply commands, at a minimal number of points. We don't know how to achieve that hypothetical (graph problems are difficult).
+However, if contributors find a solution later, they will be able to build on top of this design.
+
+Therefore, although `apply_system_buffers` might not be the best way to handle this, it will let users decide when commands are applied and ensure other systems aren't running when that happens.
+We think that's good enough for now.
+
+(Maybe instead of `apply_system_buffers` applying the pending commands of *all* systems in the current schedule, we could construct `apply_system_buffers` from a tuple of system (set) labels, such that only those have their commands applied.
+It's debatable whether that would increase or reduce cognitive burden.
+That can be revisited later too.)
+
 ### Why did you change states from a stack to a basic FSM? Where is `OnUpdate(X)`?
 
 If this RFC is merged and this design is implemented, we expect most of the problems that encouraged it to vanish.

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -141,7 +141,6 @@ fn main() {
 The main way you can configure systems is to say *when* they should run, using the `.before`, `.after`, and `.in_set` methods.
 These properties, called *dependencies*, determine execution order relative to other systems and system sets.
 These dependencies are collected and assembled to produce dependency graphs, which, along with the signature of each system, tells the executor which systems can run in parallel.
-
 Dependencies involving system sets are later flattened into dependencies between individual pairs of systems.
 
 If a combination of constraints cannot be satisfied (e.g. you say A has to come both before and after B), a dependency graph will be found to be **unsolvable** and return an error. However, that error should clearly explain how to fix whatever problem was detected.

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -590,11 +590,11 @@ Now, we came up with three options to actually enforce that as an invariant:
 We like (3) because it doesn't put undue burden on the user or introduce unclear implicit behavior.
 Likewise, resolving the error is very simple: just name the systems.
 
-In the most common case, where the `chain!` macro is used, we can avoid forcing users to name their systems by using an automatically generated private identifier to define the ordering.
-This means that system chaining will *always* introduce new copies of a system, without attempting to reuse existing ones.
-While this is not optimal for `apply_system_buffers` or other heavily blocking systems, it is explicit, consistent and ergonomic.
+Internally, systems and sets are given unique identifiers and those are used for graph construction. This means you can do `add_system(apply_system_buffers.after(X))` multiple times or use the `chain!` macro with multiple unnamed instances of the same function without having to name any of them. A system only needs a name when you want to do `before(name)` or `after(name)` somewhere else. 
 
-See the discussion on command-flushed ordering constraints and automatic inference of sync points in Future Work for ideas on how we can improve this.
+*Note: In case it wasn't already clear, system chaining introduces new instances of systems. It does not reuse existing ones.*
+
+See the discussion on command-flushed ordering constraints and automatic inference of sync points in **Future Work** for ideas on how we can improve this.
 
 ## Unresolved questions
 

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -384,7 +384,7 @@ This design can be broken down into the following steps:
 - Normalize exclusive systems.
   - Enable scheduling exclusive systems together with other systems.
     - Make `&mut World` a system param, so all systems can be handled together as `System` trait objects. ([bevyengine/bevy#4166](https://github.com/bevyengine/bevy/pull/4166))
-  - Deal with the fact that archetypes can now change in between systems.
+  - Deal with the fact that archetypes can now change in between systems (as there's no longer a clear line between exclusive and parallel systems).
     - Defer tasks borrowing a system until just before that system runs (so we can update archetype component access last second).
       - Funnel `&Scope` into spawned tasks so a task can spawn other tasks. ([bevyengine/bevy#4466](https://github.com/bevyengine/bevy/pull/4466))
       - **Alternative**: Keep spawning tasks upfront but use channels to send systems into them and back (or cancel if skipped).

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -212,7 +212,6 @@ There are a few important subtleties to bear in mind when working with run crite
   - this occurs just before the first system controlled by that criteria would be run
   - the value is then shared for all other systems with that run criteria, ensuring all systems in the set stay synchronized
 
-Run criteria are evaluated by the executor just before the system that they are controlling is run: it is impossible to modify the data that they rely on in an observable way before the system completes.
 This is important to ensure that the state of the world always matches the state expected by the system at the time it is executed.
 
 #### States

--- a/rfcs/45-stageless.md
+++ b/rfcs/45-stageless.md
@@ -440,9 +440,9 @@ And if their public API is relatively stable, plugins could even make large inte
 
 You *will* have to be more careful once exclusive systems can go anywhere.
 
-That said, the executor won't fail to detect pairs of conflicting + ambiguously-ordered things.
+That said, the dependency graph checker won't fail to detect pairs of conflicting + ambiguously-ordered things.
 The checker can point out what's ambiguous before *and* after flattening dependency graphs.
-(i.e. the executor can report that system A conflicts with system set X before reporting the specific pairs of conflicting systems).
+(i.e. the checker can report that system A conflicts with system set X before reporting the specific pairs of conflicting systems).
 
 We hope system sets will help reduce the cognitive burden here and naturally lead users to patterns with fewer errors.
 Likewise, if users also become responsible for scheduling sets exported by plugins, it will be within their power to resolve any errors.
@@ -454,7 +454,8 @@ If you have two ambiguously-ordered system sets that conflict, you probably won'
 
 ### Why is command application scheduled with an exclusive system?
 
-Several earlier RFCs talked about expressing more exact dependencies, e.g. `B.after_buffers_of(A)`, where such graph edges could hypothetically be used to automatically determine when to apply commands, at a minimal number of points. We don't know how to achieve that hypothetical (graph problems are difficult).
+Several earlier RFCs talked about expressing more exact dependencies, e.g. `B.after_buffers_of(A)`, where such graph edges could hypothetically be used to automatically determine when to apply commands, at a minimal number of points.
+We don't know how to achieve that hypothetical (graph problems are difficult).
 However, if contributors find a solution later, they will be able to build on top of this design.
 
 Therefore, although `apply_system_buffers` might not be the best way to handle this, it will let users decide when commands are applied and ensure other systems aren't running when that happens.


### PR DESCRIPTION
[**RENDERED**](https://github.com/alice-i-cecile/rfcs/blob/stageless/rfcs/45-stageless.md)

This RFC is now ready for final review. Feedback is welcome from users at all levels! Do you think this design easy-to-understand, useful and correct? How could the proposed API be improved?

## TL; DR

- Systems: now stored in the `World`
- Exclusive systems: no longer special-cased
- System sets: now just pure metadata, define order and conditions of groups of systems
- Schedules: now the executable instances of system sets, also stored in the `World`
- Run criteria: replaced by combineable, non-mutating, `bool`-returning functions
- States: now powered by new exclusive system + schedule combo instead of run criteria
- Fixed timestep: now powered by new exclusive system + schedule combo instead of run criteria
- Commands: now applied with an exclusive system
- Stages: yeet
- All of the awful bugs with stages, states, and run criteria: replaced with new, yet-to-be-discovered bugs!

Plus, some shiny new toys: running systems in commands and modifying schedules at runtime!

## Prototype

[iyes_loopless](https://github.com/IyesGames/iyes_loopless) is a Bevy 0.6-compatible third-party implementation of the core ideas of how this RFC handles run criteria and states. Go try it out!

## Context

This is the culmination of many months of discussion, work, debate and mind-melting from @maniwani (Joy), @hymm (WrongShoe) and myself; they should be considered equal coauthors on this RFC. If you're curious about the background, check out https://github.com/bevyengine/bevy/discussions/2801 to get a sense of the tangled mess we're trying to clean up.

Special thanks to @Ratysz and the rest of the ECS crew for all of the feedback and guidance throughout the process.

## Meta
What is the best way to handle the migration process from an organizational perspective?
  - Get an RFC approved, and then merge a massive PR developed on a off-org branch?
    - Straightforward, but very hard to review
    - Risks divergence and merge conflicts
  - Use an official branch with delegated authority?
    - Easier to review, requires delegation, ultimately creates a large PR that needs to be reviewed
    - Risks divergence and merge conflicts
  - Develop `bevy_schedule3` on the `main` branch as a partial fork of `bevy_ecs`?
    - Some annoying machinery to set up
    - Requires more delegation and trust to ECS team
    - Avoids divergence and merge conflicts
    - Clutters the main branch