### PR TITLE
Reflexive world queries

### DIFF
--- a/rfcs/68-reflexive-world-queries.md
+++ b/rfcs/68-reflexive-world-queries.md
@@ -121,8 +121,7 @@ To support this change, we will need to rework some of our built-in
 `WorldQuery` types to be reflexive.
 
 ```rust
-fn my_system(q: Query<AnyOf<(&A, &B, &C)>>) {
-
+fn any_system(q: Query<AnyOf<(&A, &B, &C)>>) {
     // Before:
     for (a, b, c) in &q {
         ...
@@ -130,6 +129,18 @@ fn my_system(q: Query<AnyOf<(&A, &B, &C)>>) {
     
     // After:
     for AnyOf((a, b, c)) in &q {
+        ...
+    }
+}
+
+fn changed_system(q: Query<Changed<A>>) {
+    // Before:
+    for changed_a in &q {
+        ...
+    }
+    
+    // After:
+    for Changed(changed_a) in &q {
         ...
     }
 }


### PR DESCRIPTION
[RENDERED](https://github.com/JoJoJet/rfcs/blob/reflexive-world-queries/rfcs/68-reflexive-world-queries.md).

Currently, the `#[derive(WorldQuery)]` macro produces types with a sub-par API. For each user-defined type, the macro generates an additional "Item" type associated with it, and the API is spread between these two types in a way that increases complexity and makes custom world query types more difficult to use and create. I propose we amend this by requiring derived world queries to be reflexive, which removes the need for "Item" types.